### PR TITLE
Support for GNU hostname command

### DIFF
--- a/gufw/gufw/model/ufw_backend.py
+++ b/gufw/gufw/model/ufw_backend.py
@@ -15,7 +15,7 @@
 # along with Gufw; if not, see http://www.gnu.org/licenses for more
 # information.
 
-import time, os, shutil, subprocess, configparser
+import time, os, shutil, subprocess, configparser, socket
 
 
 class Backend():
@@ -469,15 +469,38 @@ class Backend():
         
         return result
     
-    def get_net_ip(self):
-        cmd_ip = ['hostname', '--all-ip-addresses']
-        cmd = self._run_cmd(cmd_ip)
-        ips = cmd.split('\n')
+    def check_valid_ip(self, ip):
+        try:
+            socket.inet_aton(ip)
+            return True
+        except:
+            return False
+
+    def get_net_ip(self, gnu_hostname=False):
+        if not gnu_hostname:
+            cmd_ip = ['hostname', '--all-ip-addresses']
+            cmd = self._run_cmd(cmd_ip)
+            ips = cmd.split('\n')
         
-        if len(ips) > 0:
-            return ips[0].strip()
+            if len(ips) > 0:
+                ip_str = ips[0].strip()
+                if self.check_valid_ip(ip_str):
+                    return ip_str
+                else:
+                    return self.get_net_ip(gnu_hostname=True)
+            else:
+                return '127.0.0.1'
         else:
-            return '127.0.0.1'
+            cmd_ip = ['hostname', '--ip-addresses']
+            cmd = self._run_cmd(cmd_ip)
+            ips = cmd.split(' ')
+
+            if len(ips) > 0:
+                ip_str = ips[0].strip()
+                if self.check_valid_ip(ip_str):
+                    return ip_str
+                else:
+                    return '127.0.0.1'
     
     def get_listening_report(self):
         return_report = []


### PR DESCRIPTION
I noticed on clicking the "Paste your current local IP" the command `hostname --all-ip-addresses` is run. But with the GNU version of the hostname that I have pre installed on Arch Linux does not have this option. Instead it uses `--ip-addresses` option. So I've added a check for valid IP addresses that the command returns (as for me the command returned an error message string) and some logic to try the GNU version's option before falling back to 127.0.0.1.

Lemme know your thoughts. Thanks !

<details>
<summary>FYR, some info on the GNU version of hostname</summary>

```
hostname --help

Usage: hostname [OPTION...] [NAME]
Show or set the system's host name.

-a, --aliases              alias names
-d, --domain               DNS domain name
-f, --fqdn, --long         DNS host name or FQDN
-F, --file=FILE            set host name or NIS domain name from FILE
-i, --ip-addresses         addresses for the host name
-s, --short                short host name
-y, --yp, --nis            NIS/YP domain name
-?, --help                 give this help list
--usage                give a short usage message
-V, --version              print program version

Mandatory or optional arguments to long options are also mandatory or optional
for any corresponding short options.

Report bugs to <bug-inetutils@gnu.org>


hostname --version

hostname (GNU inetutils) 2.2
Copyright (C) 2021 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Debarshi Ray.
```
</details>