### PR TITLE
allow to send rules on status=False

### DIFF
--- a/gufw/gufw/model/firewall.py
+++ b/gufw/gufw/model/firewall.py
@@ -132,7 +132,7 @@ class Firewall():
     def set_status(self, status):
         self.status = status
         self.backend.set_status(status)
-        self.backend.set_profile_values(self.profile, status, self.incoming, self.outgoing, self.routed, self.get_rules(False))
+        self.backend.set_profile_values(self.profile, status, self.incoming, self.outgoing, self.routed, self.get_rules(not status))
     
     def get_policy(self, policy):
         if policy == 'incoming':


### PR DESCRIPTION
Right now when 'Status' toggle is set to 'off', any rules created/managed by Gufw are wiped from the configuration file. When re-enabling, the resulting ufw rules are loaded as immutable ones, and there is no easy way to manage them.

This PR allows to pass rules to the function responsible for writing the profile, and as a result, the rules persist in the config file.
