### PR TITLE
Updated GUFW to ensure absolute path of `gufw-pkexec` is always used.

### DIFF
--- a/bin/gufw
+++ b/bin/gufw
@@ -1,3 +1,3 @@
 #!/bin/bash
 c_user=$(whoami)
-pkexec gufw-pkexec $c_user
+pkexec "$(which gufw-pkexec)" $c_user


### PR DESCRIPTION
# Problem

When running `gufw` from the command line I came across this error:

```
(gufw.py:442919): Gtk-CRITICAL **: 23:10:39.470: _gtk_style_provider_private_get_settings: assertion 'GTK_IS_STYLE_PROVIDER_PRIVATE (provider)' failed
/usr/bin//gufw-pkexec: line 2: 442919 Segmentation fault      (core dumped) python3 /usr/lib/python3.10/site-packages/gufw/gufw.py "$@"
```

# Explanation

The important bit is **`/usr/bin//gufw-pkexec`**

In the polkit **com.ubuntu.pkexec.gufw.policy** file it has this line:

`<annotate key="org.freedesktop.policykit.exec.path">/usr/bin/gufw-pkexec</annotate>`

Polkit does not recognize the paths being the same since it includes a double forward slash ('//').

I confirmed this was the issue by adding this line into this file: 

`<annotate key="org.freedesktop.policykit.exec.path">/usr/bin//gufw-pkexec</annotate>`

Which when I restarted the polkit service I was able to run the program without error.

Obviously this is not a good solution as it would not solve any other forward slash issue, so I provided a better solution, which can be seen in my pull request.

# Solution: Get Absolute Path of `gufw-pkexec`

Before:
`pkexec gufw-pkexec $c_user` 

After:
`pkexec "$(which gufw-pkexec)" $c_user`

**This ensures the correct path of `gufw-pkexec` will always be sent.**


---




