### PR TITLE
App Profile For Syncthing

### DIFF
--- a/data/app_profiles/syncthing.jhansonxi
+++ b/data/app_profiles/syncthing.jhansonxi
@@ -1,0 +1,13 @@
+[Syncthing Sync]
+title=Syncthing Sync
+description=Syncthing UDP/TCP based sync protocol traffic (default port)
+ports=22000
+categories=Network;File Transfer;
+reference=[https://docs.syncthing.net/users/firewall.html#local-firewall docs.syncthing.net: Local Firewall]
+
+[Syncthing Local Discovery]
+title=Syncthing Local Discovery
+description=Syncthing discovery broadcasts on IPv4 and multicasts on IPv6 (default port)
+ports=21027/udp
+categories=Network;File Transfer;
+reference=[https://docs.syncthing.net/users/firewall.html#local-firewall docs.syncthing.net: Local Firewall]


### PR DESCRIPTION
App profile for [syncthing](https://syncthing.net/), see [documentation on firewall exceptions](https://docs.syncthing.net/users/firewall.html#local-firewall).

I found that on my Linux Mint installation with gufw enabled, syncthing local discovery would not work. Just adding the port 21027 entry seemd to do the trick, but just to be sure I also added the sync port 22000 entry as the documentation advises.

Thanks for considering this PR :)