### PR TITLE
Switch from webkit2gtk 4.0 to 4.1

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -4,7 +4,7 @@
 DEPENDENCIES
 -----------------
 ufw 0.34+ for Gufw 14.10+
-gir1.2-webkit2-4.0
+gir1.2-webkit2-4.1
 gir1.2-gtk-3.0
 gnome-icon-theme-symbolic
 policykit-1

--- a/gufw/gufw/view/gufw.py
+++ b/gufw/gufw/view/gufw.py
@@ -18,7 +18,7 @@
 import gi
 gi.require_version('Gtk', '3.0')
 gi.require_version('Gdk', '3.0')
-gi.require_version('WebKit2', '4.0')
+gi.require_version('WebKit2', '4.1')
 from gi.repository import Gtk, Gdk, WebKit2
 from string import Template
 


### PR DESCRIPTION
Fedora has removed [webkitgtk 4.0](https://fedoraproject.org/wiki/Changes/Remove_webkit2gtk-4.0_API_Version) in preparation for Fedora 40 in a few months. Debian and Ubuntu are working on that too.

webkitgtk 4.1 is the same as 4.0 except that 4.1 uses libsoup3 and 4.0 uses libsoup2.4. Since gufw doesn't use libsoup directly, this is an easy switch.

webkitgtk 4.1 is available in Ubuntu 22.04 LTS, Debian 12, and other actively supported distros.