### PR TITLE
Fix gdk crash

### DIFF
--- a/bin/gufw
+++ b/bin/gufw
@@ -1,3 +1,3 @@
 #!/bin/bash
 c_user=$(whoami)
-pkexec "$(which gufw-pkexec)" $c_user
+pkexec "$(readlink -f $(which gufw-pkexec))" $c_user


### PR DESCRIPTION
Fixes #73.

The problem and solution are also explained here: https://bbs.archlinux.org/viewtopic.php?id=267747, and something very similar happened in #57 as well.

To summarise, there is a polkit rule in **com.ubuntu.pkexec.gufw.policy** which points to `/usr/bin/gufw-pkexec`.
The **gufw** script called `gufw-pkexec` **without** specifying its full path, which caused issues.
#57 fixed it by replacing the call with `$(which gufw-pkexec)`.
However, this can resolve to other paths, like `/sbin/gufw-pkexec`, which is a link to `/usr/bin/gufw-pkexec`, so it crashes.

This is why `readlink -f` has to be used to always point to the original, `/usr/bin/gufw-pkexec` path.
As an alternative you could just add `/usr/bin/gufw-pkexec` to avoid these commands, as it is already expected that they will resolve to that.