### PR TITLE
Miracast/Airplay Profile

### DIFF
--- a/data/app_profiles/miracast.gufw
+++ b/data/app_profiles/miracast.gufw
@@ -1,0 +1,6 @@
+[chromecast]
+title=MiracastAirplay
+description=Miracast or Airplay Stream device
+ports=51570/udp|5353/udp|7000/udp|18000:18009/udp|7236/tcp|50000/tcp|51571/tcp|7100/tcp|18000:18009/tcp
+categories=Audio Video;TV;
+reference=[https://help.flatfrog.com/en/knowledge/screensharing]

--- a/data/app_profiles/miracast.gufw
+++ b/data/app_profiles/miracast.gufw
@@ -1,4 +1,4 @@
-[chromecast]
+[miracastairplay]
 title=MiracastAirplay
 description=Miracast or Airplay Stream device
 ports=51570/udp|5353/udp|7000/udp|18000:18009/udp|7236/tcp|50000/tcp|51571/tcp|7100/tcp|18000:18009/tcp


### PR DESCRIPTION
Add rules needed to share screen via "GNOME Network Displays" application to miracast devices.

The ports mentioned by https://help.flatfrog.com/en/knowledge/screensharing seems to be sufficient. Tested with LG TV.