### PR TITLE
Add "ufw" keyword for .desktop file

### DIFF
--- a/gufw.desktop.in
+++ b/gufw.desktop.in
@@ -2,7 +2,7 @@
 Version=1.0
 _Name=Firewall Configuration
 _Comment=An easy way to configure your firewall
-Keywords=gufw;security;firewall;network;
+Keywords=gufw;ufw;security;firewall;network;
 Categories=GNOME;GTK;Settings;Security;X-GNOME-Settings-Panel;X-GNOME-SystemSettings;X-Unity-Settings-Panel;X-XFCE-SettingsDialog;X-XFCE-SystemSettings;
 Exec=gufw
 Icon=gufw


### PR DESCRIPTION
Not every DE in Linux is smart enough to find gufw by "ufw" as a part of word like KDE Plasma.